### PR TITLE
Can run hdfs-shell.sh and hdfs-shell-daemon.sh scripts from anywhere.

### DIFF
--- a/deploy/bin/hdfs-shell-daemon.sh
+++ b/deploy/bin/hdfs-shell-daemon.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -Ddaemon=true -Xms200m -Xmx400m -cp ./lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"
+CWD=$(cd $(dirname $0); pwd)  
+
+java -Ddaemon=true -Xms200m -Xmx400m -cp ${CWD}/lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"

--- a/deploy/bin/hdfs-shell.sh
+++ b/deploy/bin/hdfs-shell.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-java -Xms200m -Xmx400m -cp ./lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"
+CWD=$(cd $(dirname $0); pwd)  
+
+java -Xms200m -Xmx400m -cp ${CWD}/lib/*:/etc/hadoop/conf com.avast.server.hdfsshell.MainApp "$@"


### PR DESCRIPTION
#Problem
These two scripts use ./lib path for -cp option. As a result, it fails to run if the current working directory is not bin directory.

#Solution
This fix uses a few simple bash commands to resolve the relative path from the current working directory to the lib directory.
